### PR TITLE
Интеграция с ELK (старым) для логов

### DIFF
--- a/pipeline/docker-compose.yml
+++ b/pipeline/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     restart: unless-stopped
     networks:
       - app
+    logging:
+      driver: gelf
+      options:
+        gelf-address: "udp://localhost:12201"
+        tag: "svetit_web"
 
   db:
     container_name: svetit_db
@@ -128,6 +133,43 @@ services:
       - app
     restart: unless-stopped
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    environment:
+      - discovery.type=single-node
+    ports:
+      - 9200:9200
+    volumes:
+      - elastic_data:/usr/share/elasticsearch/data
+    networks:
+      - app
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.6.2
+    ports:
+      - 5601:5601
+    depends_on:
+      - elasticsearch
+      - logstash
+    volumes:
+      - kibana_data:/usr/share/kibana/data
+    networks:
+      - app
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:7.6.2
+    links:
+      - elasticsearch
+    volumes:
+      - ./elk/logstash:/etc/logstash
+    command: logstash -f /etc/logstash/logstash.conf
+    ports:
+      - 12201:12201/udp
+    depends_on:
+      - elasticsearch
+    networks:
+      - app
+
   cpp_deps:
     image: cpp_deps:latest
     build:
@@ -178,6 +220,11 @@ services:
         restart: true
     networks:
       - app
+    logging:
+      driver: gelf
+      options:
+        gelf-address: "udp://localhost:12201"
+        tag: "svetit_auth"
 
   space:
     container_name: svetit_space
@@ -206,6 +253,11 @@ services:
     restart: unless-stopped
     networks:
       - app
+    logging:
+      driver: gelf
+      options:
+        gelf-address: "udp://localhost:12201"
+        tag: "svetit_space"
 
   project:
     container_name: svetit_project
@@ -228,6 +280,11 @@ services:
     restart: unless-stopped
     networks:
       - app
+    logging:
+      driver: gelf
+      options:
+        gelf-address: "udp://localhost:12201"
+        tag: "svetit_project"
 
   node:
     container_name: svetit_node
@@ -251,6 +308,11 @@ services:
     restart: unless-stopped
     networks:
       - app
+    logging:
+      driver: gelf
+      options:
+        gelf-address: "udp://localhost:12201"
+        tag: "svetit_node"
 
 volumes:
   pg_data:
@@ -265,6 +327,12 @@ volumes:
   grafana_data:
     driver: local
     name: svetit_grafana_data
+  kibana_data:
+    driver: local
+    name: svetit_kibana_data
+  elastic_data:
+    driver: local
+    name: svetit_elastic_data
 
 networks:
   app:

--- a/pipeline/elk/logstash/logstash.conf
+++ b/pipeline/elk/logstash/logstash.conf
@@ -1,0 +1,11 @@
+input {
+    gelf {
+        port => 12201
+    }
+}
+output {
+    elasticsearch {
+        hosts => ["elasticsearch:9200"]
+        index => "logstash-%{+YYYY-MM-dd}"
+    }
+}


### PR DESCRIPTION
Не подходит для реального использования, так как ELK устаревший. А новый хочет около 10 ГБ ОЗУ.