### PR TITLE
Запуск прокси проекта для отладки через GDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ run-bin-%: generate-schemas
 	make -C src/back/$* build-debug
 	./pipeline/run_bin.sh $*
 
+run-proxy-for-gdb-%: generate-schemas
+	./pipeline/run_proxy_for_gdb.sh $*
+
 test-%: generate-schemas
 	make -C src/back/$* test-debug
 

--- a/pipeline/run_proxy_for_gdb.sh
+++ b/pipeline/run_proxy_for_gdb.sh
@@ -108,7 +108,7 @@ set -m
 trap 'restoreApiGatewayHosts' SIGINT
 
 echo "Starting proxy for GDB, app should be running already"
-echo "Also please not run it with other make run-bin-% runned services (side effects) or run it carefully. Hosts replacements may not work right for such case - or you should switch off gdb service before making ctrl+c of other make run-bin-% runned service."
+echo "Also please run it with other make run-bin-% runned services carefully."
 
 replaceApiGatewayHostsAfterAppStarted
 

--- a/pipeline/run_proxy_for_gdb.sh
+++ b/pipeline/run_proxy_for_gdb.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+SCRIPT_PATH=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
+
+getAppPath() {
+	local res="$SCRIPT_PATH/../src/back/$1/build_debug"
+	[ -d "$res" ] && echo "$res"
+}
+
+APP=$1
+APP_PATH=$(getAppPath $APP)
+if [ -z "$APP" ] || [ -z "$APP_PATH" ]; then
+	>&2 echo "Usage: $0 {app_name}"
+	>&2 echo "App '$APP' must be built"
+	exit 1
+fi
+
+isApiGwHostsReplaced=0
+apiGwName=svetit_web
+
+checkIsPortOpen() {
+	ss -ltn | grep $1 >/dev/null
+	return $?
+}
+
+genExtraHostsArgs() {
+	local res=
+	local data=$(grep '_PORT=' "$SCRIPT_PATH/.env")
+	for i in $data; do
+		[[ "$i" =~ ([A-Za-z_]+)_PORT[^0-9]*([0-9]+) ]] || continue
+		name="${BASH_REMATCH[1],,}"
+		port="${BASH_REMATCH[2]}"
+
+		# check is app folder exists
+		[ -z "$(getAppPath $name)" ] && continue
+
+		checkIsPortOpen $port
+		[ $? -eq 0 ] || continue
+
+		res+=" --add-host $name:host-gateway"
+	done
+	echo "$res"
+}
+
+genExtraHostsArgsExceptApp() {
+	local res=
+	local data=$(grep '_PORT=' "$SCRIPT_PATH/.env")
+	for i in $data; do
+		[[ "$i" =~ ([A-Za-z_]+)_PORT[^0-9]*([0-9]+) ]] || continue
+		name="${BASH_REMATCH[1],,}"
+		port="${BASH_REMATCH[2]}"
+
+		if [ "$APP" == "$name" ]; then
+			continue;
+		fi
+
+		# check is app folder exists
+		[ -z "$(getAppPath $name)" ] && continue
+
+		checkIsPortOpen $port
+		[ $? -eq 0 ] || continue
+
+		res+=" --add-host $name:host-gateway"
+	done
+	echo "$res"
+}
+
+replaceApiGatewayHostsAfterAppStarted() {
+	# break if Api Gateway container is not running
+	if [ "$( docker container inspect -f '{{.State.Running}}' $apiGwName )" != "true" ]; then
+		echo "API Gateway ports can't be replaced because container stoped"
+		return 0
+	fi
+	echo -e "\033[0;36mBegin replace API Gateway hosts\033[0m"
+
+	docker stop $apiGwName svetit_$APP
+	docker rm $apiGwName 2>&1 >/dev/null
+
+	extraHosts=$(genExtraHostsArgs)
+	docker run --rm --net=svetit_app -p 8080:80 $extraHosts -d --name $apiGwName $apiGwName
+
+	echo -e "\033[1;32mApi gateway hosts replaced\033[0m"
+	isApiGwHostsReplaced=1
+}
+
+restoreApiGatewayHosts() {
+	[ $isApiGwHostsReplaced -eq 1 ] || return 0
+	isApiGwHostsReplaced=0
+	extraHosts=$(genExtraHostsArgsExceptApp)
+	if [ -n "$extraHosts" ]; then
+		docker stop $apiGwName
+		docker compose -f "$SCRIPT_PATH/docker-compose.yml" up -d $APP
+		sleep 3
+		docker run --rm --net=svetit_app -p 8080:80 $extraHosts -d --name $apiGwName $apiGwName
+		echo "Api gateway host for $APP returned"
+	else
+		docker stop $apiGwName
+		docker rm $apiGwName 2>&1 >/dev/null
+		docker compose -f "$SCRIPT_PATH/docker-compose.yml" up -d web $APP
+		echo "Api gateway hosts returned"
+	fi
+}
+
+# enable jobs manage
+set -m
+
+# catch Ctrl+C
+trap 'restoreApiGatewayHosts' SIGINT
+
+echo "Starting proxy for GDB, app should be running already"
+echo "Also please not run it with other make run-bin-% runned services (side effects) or run it carefully. Hosts replacements may not work right for such case - or you should switch off gdb service before making ctrl+c of other make run-bin-% runned service."
+
+replaceApiGatewayHostsAfterAppStarted
+
+while true
+do
+	sleep 1
+done
+
+restoreApiGatewayHosts


### PR DESCRIPTION
Этот ПР нужен для встраивания сервиса, запущенного в отладчике VS Code (gdb), в общую систему. И позволяет перенаправлять на отладчик запросы из прокси.

В этом ПР я попытался реализовать make команду для запуска скрипта, который представляет собой сокращенный run-bin.sh. Суть в том, чтобы погасить svetit_web (прокси) и запустить его заново с extra hosts, как мы делаем при запуске через make run-bin-%. Но в текущем скрипте мы не запускаем сам сервис, так как он запускается в VS Code (и должен был запущен до выполнения команды make run-proxy-for-gdb-%). 

Также текущий ПР реализует более-менее умное завершение работы скрипта, которое учитывает возможную запущенность других сервисов через make run-bin-%. Однако в этом есть и недоработка - чтобы всё работало корректно, нужно после завершения работы make run-proxy-for-gdb-%, завершить работу сервиса в отладчике GDB. Иначе когда будет завершаться работа другого сервиса, запущенного через make run-bin-%, то run-bin.sh увидит, что сервис в GDB работает, и не погасит временную проксю должны образом. Чтобы это пофиксить, нам, наверное, нужно придумать и реализовать какой-то дополнительный признак, что конкретный сервис запущен в отладчике. Чтобы make run-bin-% (run-bin.sh) не учитывал его работу при своём завершении.